### PR TITLE
Increased the sandpit, dev and auto-test delius db disk to 1000gb fro…

### DIFF
--- a/delius-auto-test/sub-projects/delius-core.tfvars
+++ b/delius-auto-test/sub-projects/delius-core.tfvars
@@ -10,8 +10,8 @@ db_size_delius_core = {
   instance_type  = "t3.large"
   disk_iops      = 1000
   disks_quantity = 2  # Do not decrease this
-  disk_size      = 200 # Do not decrease this
-  # total_storage  = 400 # This should equal disks_quantity x disk_size
+  disk_size      = 500 # Do not decrease this
+  # total_storage  = 1000 # This should equal disks_quantity x disk_size
 }
 
 ansible_vars_oracle_db = {

--- a/delius-core-dev/sub-projects/delius-core.tfvars
+++ b/delius-core-dev/sub-projects/delius-core.tfvars
@@ -10,8 +10,8 @@ db_size_delius_core = {
   instance_type  = "t3.large"
   disk_iops      = 1000
   disks_quantity = 2  # Do not decrease this
-  disk_size      = 100 # Do not decrease this
-  # total_storage  = 200 # This should equal disks_quantity x disk_size
+  disk_size      = 500 # Do not decrease this
+  # total_storage  = 1000 # This should equal disks_quantity x disk_size
 }
 
 ansible_vars_oracle_db = {

--- a/delius-core-sandpit/sub-projects/delius-core.tfvars
+++ b/delius-core-sandpit/sub-projects/delius-core.tfvars
@@ -9,9 +9,9 @@ db_size_delius_core = {
   database_size  = "small"
   instance_type  = "t3.large"
   disk_iops      = 1000
-  disks_quantity = 8  # Do not decrease this
-  disk_size      = 100 # Do not decrease this
-  # total_storage  = 200 # This should equal disks_quantity x disk_size
+  disks_quantity = 2  # Do not decrease this
+  disk_size      = 500 # Do not decrease this
+  # total_storage  = 1000 # This should equal disks_quantity x disk_size
 }
 
 ansible_vars_oracle_db = {


### PR DESCRIPTION
…m 200gb to enable the po-test database backup import.

Note: DBs on env are to be destroyed via TF before applying pipeline job to redeploy.

Closes #241 