### PR TITLE
Temporary change of MPX container to be an all-in-one SPG server

### DIFF
--- a/delius-core-sandpit/sub-projects/spg.tfvars
+++ b/delius-core-sandpit/sub-projects/spg.tfvars
@@ -66,7 +66,7 @@ spg_build_inv_dir = "/tmp/ansible/inventories/hmpps/non-prod/sandpit"
 //spg_mpx_ecs_cpu_units = 1024
 spg_mpx_ecs_memory = 3835
 SPG_MPX_JAVA_MAX_MEM = 3645
-SPG_MPX_HOST_TYPE = "hybrid"
+SPG_MPX_HOST_TYPE = "allinone"
 
 //spg_crc_ecs_cpu_units = 1024
 spg_crc_ecs_memory = 1881


### PR DESCRIPTION
Change the MPX container to be an all-in-one SPG server to temporarily allow testing of DAM-22
until the connectivity and certificate issues have been resolved