### PR TITLE
Adding PSN Proxies to prod access.

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -188,6 +188,9 @@ user_access_cidr_blocks = [
   "194.33.196.0/25",   # ARK internet (DOM1)
   "194.33.197.0/25",   # ARK internet (DOM1)
   "62.232.198.68/28",  # I2N 
+  "81.187.190.127/32", # Lazzurs Home
+  "3.10.56.113/32",    # PSN Proxy A
+  "35.178.173.171/32", # PSN Proxy B
 ]
 
 # jenkins access

--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -191,6 +191,7 @@ user_access_cidr_blocks = [
   "81.187.190.127/32", # Lazzurs Home
   "3.10.56.113/32",    # PSN Proxy A
   "35.178.173.171/32", # PSN Proxy B
+  "82.38.248.151/32",  # Steve James Office
 ]
 
 # jenkins access


### PR DESCRIPTION
This should allow PSN proxies to the allow list for production
environments.

Also adding in my home for the transition and to allow testing.