### PR TITLE
Change the public IP of PSN Proxy B

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -197,7 +197,7 @@ user_access_cidr_blocks = [
   "62.232.198.64/28",  # I2N 
   "81.187.190.127/32", # Lazzurs Home
   "3.10.56.113/32",    # PSN Proxy A
-  "35.178.173.171/32", # PSN Proxy B
+  "35.176.141.197/32", # PSN Proxy B
   "82.38.248.151/32",  # Steve James Office
   "213.86.81.13/32",   # Zaizi London Office
 ]

--- a/delius-pre-prod/sub-projects/parent-orgs.tfvars
+++ b/delius-pre-prod/sub-projects/parent-orgs.tfvars
@@ -74,7 +74,7 @@ PO_SPG_FIREWALL_INGRESS_RULES = {
   #POSTUB="no longer derived from vpc x 3 NAT as part of LB terraform as now external facing"
 
   PSNPROXY_A = "3.10.56.113/32"
-  PSNPROXY_B = "35.178.173.171/32"
+  PSNPROXY_B = "35.176.141.197/32"
 
 
 }
@@ -89,5 +89,5 @@ psn_facing_ips = [
 
 internet_facing_ips = [
   "3.10.56.113",
-  "35.178.173.171"
+  "35.176.141.197"
 ]

--- a/delius-prod/sub-projects/parent-orgs.tfvars
+++ b/delius-prod/sub-projects/parent-orgs.tfvars
@@ -77,7 +77,7 @@ PO_SPG_FIREWALL_INGRESS_RULES = {
   #POSTUB="no longer derived from vpc x 3 NAT as part of LB terraform as now external facing"
 
   PSNPROXY_A = "3.10.56.113/32"
-  PSNPROXY_B = "35.178.173.171/32"
+  PSNPROXY_B = "35.176.141.197/32"
 
 
 }
@@ -92,5 +92,5 @@ psn_facing_ips = [
 
 internet_facing_ips = [
   "3.10.56.113",
-  "35.178.173.171"
+  "35.176.141.197"
 ]

--- a/delius-prod/sub-projects/prod-parent-orgs.tfvars
+++ b/delius-prod/sub-projects/prod-parent-orgs.tfvars
@@ -75,7 +75,7 @@ PO_SPG_FIREWALL_INGRESS_RULES = {
   #POSTUB="no longer derived from vpc x 3 NAT as part of LB terraform as now external facing"
 
   PSNPROXY_A = "3.10.56.113/32"
-  PSNPROXY_B = "35.178.173.171/32"
+  PSNPROXY_B = "35.176.141.197/32"
 
 
 }
@@ -90,5 +90,5 @@ psn_facing_ips = [
 
 internet_facing_ips = [
   "3.10.56.113",
-  "35.178.173.171"
+  "35.176.141.197"
 ]


### PR DESCRIPTION
Changing the public IP of PSN Proxy B to an Elastic IP to allow
scaling up the instance and all the good things like that.