### PR TITLE
Reflecting manual changes made during LDAP downtime.

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -274,11 +274,11 @@ backup_retention_days = 30
 snapshot_retention_days = 30
 
 # Default values for LDAP
-instance_type_ldap = "i3.xlarge"
+instance_type_ldap = "c5.metal"
 ldap_disk_config = {
   volume_type = "io1"
   volume_size = 100
-  iops        = 1500
+  iops        = 5000
 }
 default_ansible_vars_apacheds = {
   workspace = "/root/bootstrap-workspace"


### PR DESCRIPTION
The production instance is currently a c5.metal and has 5000 IOPS
allocated to the EBS.