### PR TITLE
Adding the IP of the Azure NDH

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -462,6 +462,10 @@ loadrunner_config = {
   "instance_type" = "m5.2xlarge"
 }
 
+azure_oasys_proxy_source = [
+  "51.140.255.11/32" # Public IP of Fix & Go Azure API Gateway used for NDH
+]
+
 #these 3 vars dictate whether or not to use AmazonMQ, vs spg-mpx-broker ('data'|'var')
 #var = spg local MQ, data = amazon mq
 SPG_GATEWAY_MQ_URL_SOURCE    = "var"

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -413,6 +413,11 @@ loadrunner_config = {
   "instance_type" = "t3.micro"
 }
 
+azure_oasys_proxy_source = [
+  "51.140.255.11/32" # Public IP of Fix & Go Azure API Gateway used for NDH
+]
+
+
 #these 3 vars dictate whether or not to use AmazonMQ, vs spg-mpx-broker ('data'|'var')
 #var = spg local MQ, data = amazon mq
 SPG_GATEWAY_MQ_URL_SOURCE    = "var"


### PR DESCRIPTION
This IP is used to access the interface weblogic domains for connections
to OASys.

The path is OASys -> Tibco(NDH) -> Azure API GW -> Interface load
balancer.