### PR TITLE
Added initial default ansible vars into a common inventory

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,0 +1,21 @@
+--- # all.yml
+region: eu-west-2
+
+# Buckets
+dependencies_bucket:
+  name: tf-eu-west-2-hmpps-eng-dev-delius-core-dependencies-s3bucket
+  arn: arn:aws:s3:::tf-eu-west-2-hmpps-eng-dev-delius-core-dependencies-s3bucket # (also defined in tfvars: dependencies_bucket_arn)
+
+# Delius LDAP
+# TODO update terraform/bootstrap to use ansible vars from here, instead of from the tfvars
+#      currently these vars are mostly unused, as we need releases/tagging in place before we can safely start using them
+ldap_config:
+  protocol: ldap                      # (also defined in tfvars: ldap_config["protocol"])
+  base_root: dc=moj,dc=com
+  base_users: ou=Users,dc=moj,dc=com  # (also defined in tfvars: ldap_config["base_users"])
+  bind_user: cn=admin,dc=moj,dc=com   # (also defined in tfvars: ldap_config["bind_user"])
+  import_data:
+    ldif: LATEST
+    sanitize_ldif: yes
+    base_users: ou=Users,dc=moj,dc=com
+  create_perf_test_users: 0

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -246,6 +246,18 @@ default_ansible_vars_apacheds = {
   sanitize_oid_ldif             = "yes"
   perf_test_users               = "0"
 }
+# TODO once we have releases/tagging, we can remove the ansible vars from the above to reduce it down to:
+//ldap_config = {
+//  instance_type = "t3.micro"
+//  protocol = "ldap"
+//  base_users = "ou=Users,dc=moj,dc=com"
+//  bind_user = "cn=admin,dc=moj,dc=com"
+//  disk_config = {
+//    volume_type = "io1"
+//    volume_size = 50
+//    iops        = 500
+//  }
+//}
 
 # Default values for NDelius WebLogic
 instance_type_weblogic = "t2.medium"


### PR DESCRIPTION
First step towards separating ansible(application) variables from terraform(infrastructure) vars.

This is required for the application deployment job: https://github.com/ministryofjustice/delius-manual-deployments/pull/87