### PR TITLE
added iaps_local_users paramstore keys

### DIFF
--- a/common-prod/common.credentials.yml
+++ b/common-prod/common.credentials.yml
@@ -453,6 +453,12 @@ products:
         role_name: "terraform"
         is_delegated: True
         password_length: 16
+      - name: iaps_local_users
+        type: string
+        value: 'bfortune,bwhitcomb,egregory,gmills,hcurtis,jgriffin,mcolver,nsouthgate,pchristopher,sduffy'
+        account_id: "{{ delegated_account_id }}"
+        role_name: "terraform"
+        is_delegated: True
 - name: alfresco
   namespaces:
   - name: alfresco

--- a/common/common.credentials.yml
+++ b/common/common.credentials.yml
@@ -453,6 +453,12 @@ products:
         role_name: "terraform"
         is_delegated: True
         password_length: 16
+      - name: iaps_local_users
+        type: string
+        value: 'bfortune,bwhitcomb,egregory,gmills,hcurtis,jgriffin,mcolver,nsouthgate,pchristopher,sduffy'
+        account_id: "{{ delegated_account_id }}"
+        role_name: "terraform"
+        is_delegated: True
 - name: alfresco
   namespaces:
   - name: alfresco


### PR DESCRIPTION
this key is so we can set the usernames to auto create when ASG creates a new IAPS appserver instance 