### PR TITLE
Allow dlc to run a specific Alf version

### DIFF
--- a/delius-core-dev/sub-projects/alfresco.tfvars
+++ b/delius-core-dev/sub-projects/alfresco.tfvars
@@ -59,3 +59,11 @@ alfresco_app_name = "alfresco"
 
 # spg broker url
 spg_messaging_broker_url = "tcp://spgw-jms-int.dev.delius-core.probation.hmpps.dsd.io:61616"
+
+# ASG Configuration & Alfresco release ami
+# This will override the version defined in common/common.tfvars
+# If a specific ami is required uncomment lines below and provide the ami_id
+#alfresco_asg_props = {
+#  asg_ami  = "ami-0f7eff23903506a77"
+#  image_id = "ami-0f7eff23903506a77"
+#}

--- a/delius-core-dev/sub-projects/alfresco.tfvars
+++ b/delius-core-dev/sub-projects/alfresco.tfvars
@@ -63,7 +63,7 @@ spg_messaging_broker_url = "tcp://spgw-jms-int.dev.delius-core.probation.hmpps.d
 # ASG Configuration & Alfresco release ami
 # This will override the version defined in common/common.tfvars
 # If a specific ami is required uncomment lines below and provide the ami_id
-#alfresco_asg_props = {
-#  asg_ami  = "ami-0f7eff23903506a77"
-#  image_id = "ami-0f7eff23903506a77"
-#}
+alfresco_asg_props = {
+  asg_ami  = "ami-0f7eff23903506a77"
+  image_id = "ami-0f7eff23903506a77"
+}


### PR DESCRIPTION
This change is to add config example for DLC environment.

This config will allow delius-core-dev to run a specific version if needed. 

Alfresco versions defined in common.tfvars gets updated after a release to prod. 