### PR TITLE
Adding the NDH  Bridge IP for access to the Delius Interface LB

### DIFF
--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -238,6 +238,7 @@ user_access_cidr_blocks = [
   "62.25.106.209/32",  # OMNI
   "195.92.40.49/32",   # OMNI
   "62.232.198.64/28",  # I2N
+  "51.137.128.165/32", # NDH Bridge
 ]
 
 # jenkins access

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -524,7 +524,7 @@ loadrunner_config = {
 }
 
 azure_oasys_proxy_source = [
-  "51.140.255.11/32" # Public IP of Fix & Go Azure API Gateway used for NDH
+  "51.140.255.11/32", # Public IP of Fix & Go Azure API Gateway used for NDH
   "51.137.128.165/32", # NDH Bridge
 ]
 

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -238,7 +238,6 @@ user_access_cidr_blocks = [
   "62.25.106.209/32",  # OMNI
   "195.92.40.49/32",   # OMNI
   "62.232.198.64/28",  # I2N
-  "51.137.128.165/32", # NDH Bridge
 ]
 
 # jenkins access
@@ -526,6 +525,7 @@ loadrunner_config = {
 
 azure_oasys_proxy_source = [
   "51.140.255.11/32" # Public IP of Fix & Go Azure API Gateway used for NDH
+  "51.137.128.165/32", # NDH Bridge
 ]
 
 


### PR DESCRIPTION
DAM-917

Plan

`Terraform will perform the following actions:

-/+ aws_security_group_rule.interface_lb_azure_oasys_ingress_tls (new resource required)
      id:                       "sgrule-3644874499" => <computed> (forces new resource)
      cidr_blocks.#:            "1" => "2" (forces new resource)
      cidr_blocks.0:            "51.140.255.11/32" => "51.140.255.11/32"
      cidr_blocks.1:            "" => "51.137.128.165/32" (forces new resource)
      description:              "Azure OASys Proxy Ingress (TLS)" => "Azure OASys Proxy Ingress (TLS)"
      from_port:                "443" => "443"
      protocol:                 "tcp" => "tcp"
      security_group_id:        "sg-0658aebd6885b382e" => "sg-0658aebd6885b382e"
      self:                     "false" => "false"
      source_security_group_id: "" => <computed>
      to_port:                  "443" => "443"
      type:                     "ingress" => "ingress"
`