### PR TITLE
image_verson should no longer be in spg.tfvars

### DIFF
--- a/delius-core-dev/sub-projects/spg.tfvars
+++ b/delius-core-dev/sub-projects/spg.tfvars
@@ -1,6 +1,3 @@
-#DOCKER IMAGE VERSION OF THE SPG DEPLOYABLE CODE
-image_version = "latest"
-
 # This is used for ALB logs to S3 bucket.
 # This is fixed for each region. if region changes, this changes
 lb_account_id = "652711504416"


### PR DESCRIPTION
It is controlled from the jenkins deployment jobs