### PR TITLE
Set db_max_size to a string, as hcl-parser fails due to the value being too large when calling Go's ParseInt.

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -419,7 +419,7 @@ default_ldap_config = {
   backup_retention_days = 7
   # Performance/tuning
   query_time_limit      = 30 # seconds
-  db_max_size           = 53687091200 # bytes (=50GB)
+  db_max_size           = "53687091200" # bytes (=50GB)
   # Disk
   disk_volume_type      = "io1"
   disk_volume_size      = 100 # GB

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -369,7 +369,7 @@ default_ldap_config = {
   backup_retention_days = 7
   # Performance/tuning
   query_time_limit      = 30 # seconds
-  db_max_size           = 16106127360 # bytes (=15GB)
+  db_max_size           = "16106127360" # bytes (=15GB)
   # Disk
   disk_volume_type      = "io1"
   disk_volume_size      = 30 # GB


### PR DESCRIPTION
(2147483647 strconv.ParseInt: parsing "16106127360": value out of range)