### PR TITLE
Remove some whitespace

### DIFF
--- a/delius-prod/zone_file.yml
+++ b/delius-prod/zone_file.yml
@@ -12,6 +12,6 @@ hosted_zones:
     is_apex: True
 
 # # Created manually at present, jenkins dev cannot assume jenkins prod, needs discussion
-#   - account_id: 050243167760
-#     zone_name: "delius"
-#     is_delegated: True
+#account_id: 050243167760
+#zone_name: "delius"
+#is_delegated: True


### PR DESCRIPTION
Remove some whitespace, so that the commented out account_id isn't matched by the hacky regex in delius-manual-deployments. The delius-manual-deployments repo will be updated next week to handle this scenario.