### PR TITLE
ALS-1419 Reduce LDAP disk IOPS

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -429,7 +429,7 @@ default_ldap_config = {
   # Disk
   disk_volume_type = "io1"
   disk_volume_size = 100 # GB
-  disk_iops        = 5000
+  disk_iops        = 1000
 }
 ldap_config = {}
 

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -381,7 +381,7 @@ default_ldap_config = {
   # Disk
   disk_volume_type      = "io1"
   disk_volume_size      = 30 # GB
-  disk_iops             = 1000
+  disk_iops             = 100
 }
 ldap_config = {}
 

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -357,7 +357,7 @@ snapshot_retention_days = 7
 default_ldap_config = {
   # ASG
   instance_type         = "t3.small"
-  instance_count        = 3
+  instance_count        = 2
   # Connection
   protocol              = "ldap"
   port                  = 389


### PR DESCRIPTION
The higher values are no longer required since switching to the MDB-based backup/restore process