### PR TITLE
DT-969 Set container count for pollpusher and offender search to 0 in test/preprod/prod

### DIFF
--- a/delius-pre-prod/sub-projects/new-tech.tfvars
+++ b/delius-pre-prod/sub-projects/new-tech.tfvars
@@ -73,8 +73,6 @@ offenderpollpush_conf = {
 # Override default Offender Search Service Config
 offendersearch_conf = {
   env_oauth2_jwt_jwk_set_uri = "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
-  ecs_scaling_min_capacity = 2
-  ecs_scaling_max_capacity = 10
 }
 
 offender_api_allowed_cidrs = [

--- a/delius-pre-prod/sub-projects/new-tech.tfvars
+++ b/delius-pre-prod/sub-projects/new-tech.tfvars
@@ -67,6 +67,7 @@ offenderpollpush_conf = {
   cpu    = "3072"
   memory = "4096"
   env_sns_arn_topic = "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-dbe10e8d9c1f4d100f0c723d5d9b754e"
+  desired_count     = 0
 }
 
 # Override default Offender Search Service Config

--- a/delius-prod/sub-projects/new-tech.tfvars
+++ b/delius-prod/sub-projects/new-tech.tfvars
@@ -71,6 +71,7 @@ offenderpollpush_conf = {
   cpu    = "3072"
   memory = "4096"
   env_sns_arn_topic = "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-c2d997878cd24eef94e60f1404977153"
+  desired_count     = 0
 }
 
 # Override default Offender Search Service Config

--- a/delius-prod/sub-projects/new-tech.tfvars
+++ b/delius-prod/sub-projects/new-tech.tfvars
@@ -77,8 +77,6 @@ offenderpollpush_conf = {
 # Override default Offender Search Service Config
 offendersearch_conf = {
   env_oauth2_jwt_jwk_set_uri = "https://sign-in.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
-  ecs_scaling_min_capacity = 2
-  ecs_scaling_max_capacity = 10
 }
 
 offender_api_allowed_cidrs = [

--- a/delius-test/sub-projects/new-tech.tfvars
+++ b/delius-test/sub-projects/new-tech.tfvars
@@ -47,6 +47,7 @@ web_conf = {
 # Override default Offender Poll Push Config
 offenderpollpush_conf = {
   env_sns_arn_topic = "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-453cac1179377186788c5fcd12525870"
+  desired_count     = 0
 }
 
 


### PR DESCRIPTION
By default offender search is off everywhere, whereas by default poll pusher is off in test/preprod/prod

* Poll pushers uses a set desired count
* Offender search uses a scaling count so methods to set to zero are slightly different 