### PR TITLE
Enable access from the DXW VPN

### DIFF
--- a/delius-test/sub-projects/delius-core.tfvars
+++ b/delius-test/sub-projects/delius-core.tfvars
@@ -51,7 +51,9 @@ umt_config = {
   version = "latest"
 }
 
-env_user_access_cidr_blocks = []
+env_user_access_cidr_blocks = [
+  "54.76.254.148/32" # DXW VPN
+]
 
 # DSS Batch Task
 dss_job_envvars = [


### PR DESCRIPTION
Request summary from Chris Pugh (https://mojdt.slack.com/archives/G01DWRX6Y07/p1605014483006000):
We’re part of a team building tools to support Offender Managers carrying out supervision of community sentences, which is currently carried out in Delius. We want to have team access to the a Delius environment that’s like Live but with synthetic data in it, so that we can understand more about how the current process works, to inform our designs