### PR TITLE
ALS-2057 - Added configuration for LDAP EFS + reduced specs for root EBS volume

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -432,11 +432,13 @@ default_ldap_config = {
   backup_retention_days = 7
   # Performance/tuning
   query_time_limit = 30            # seconds
-  db_max_size      = "53687091200" # bytes (=50GB)
-  # Disk
-  disk_volume_type = "io1"
-  disk_volume_size = 100 # GB
-  disk_iops        = 5000
+  db_max_size      = "53687091200" # bytes, stored on EFS (=50GB)
+  # Disk (system data + logs)
+  disk_volume_type = "gp2"
+  disk_volume_size = 50 # GB
+  # EFS (ldap data)
+  efs_throughput_mode        = "provisioned"
+  efs_provisioned_throughput = 64 # MiB/s
 }
 ldap_config = {}
 

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -386,11 +386,12 @@ default_ldap_config = {
   backup_retention_days = 7
   # Performance/tuning
   query_time_limit = 30            # seconds
-  db_max_size      = "16106127360" # bytes (=15GB)
-  # Disk
-  disk_volume_type = "io1"
+  db_max_size      = "16106127360" # bytes, stored on EFS (=15GB)
+  # Disk (system data + logs)
+  disk_volume_type = "gp2"
   disk_volume_size = 30 # GB
-  disk_iops        = 1000
+  # EFS (ldap data)
+  efs_throughput_mode = "bursting"
 }
 ldap_config = {}
 


### PR DESCRIPTION
Provisioned IOPS is no longer required for the root volume, as the LDAP data is now hosted on EFS. This should result in an EBS cost reduction.