### PR TITLE
ALS-1712 Set ActiveMQ EFS throughput to 16MiB/s

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -508,7 +508,7 @@ default_ansible_vars = {
 # Delius ActiveMQ
 default_activemq_config = {
   efs_throughput_mode        = "provisioned"
-  efs_provisioned_throughput = 10 # MiB/s
+  efs_provisioned_throughput = 16 # MiB/s
 }
 activemq_config = {}
 


### PR DESCRIPTION
Following performance test results, and risk/cost evaluation here: [ALS-1712](https://jira.engineering-dev.probation.hmpps.dsd.io/browse/ALS-1712)