### PR TITLE
🛠  PIC-545: Enable limited access markers in preprod and stage

### DIFF
--- a/delius-pre-prod/sub-projects/new-tech.tfvars
+++ b/delius-pre-prod/sub-projects/new-tech.tfvars
@@ -43,6 +43,7 @@ offenderapi_conf = {
   env_features_noms_update_multiple_events_update_bulk_key_dates = "false"
   env_features_noms_update_multiple_events_update_key_dates = "true"
   env_features_noms_update_multiple_events_update_prison_location = "true"
+  env_features_apply_limited_access_markers = "true"
 }
 
 # Override default Elasticsearch Config

--- a/delius-stage/sub-projects/new-tech.tfvars
+++ b/delius-stage/sub-projects/new-tech.tfvars
@@ -45,6 +45,7 @@ offenderapi_conf = {
   env_features_noms_update_booking_number = "true"
   env_features_noms_update_keydates = "true"
   env_features_noms_update_noms_number = "true"
+  env_features_apply_limited_access_markers = "true"
 }
 
 # Override default Elasticsearch Config


### PR DESCRIPTION
Don't merge as yet - this will be breaking for any consumers that haven't updated their clients with the required scopes in these environments.