### PR TITLE
Removed Bastion IPs from common user access CIDRs.

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -352,7 +352,6 @@ user_access_cidr_blocks = [
   "35.178.173.171/32", # PSN Proxy B
   "82.38.248.151/32",  # Steve James Office
   "213.86.81.13/32",   # Zaizi London Office
-  "35.178.165.173/32", # Bastion Dev for FoxyProxy
 ]
 
 # jenkins access

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -298,7 +298,6 @@ user_access_cidr_blocks = [
   "62.25.106.209/32",  # OMNI
   "195.92.40.49/32",   # OMNI
   "62.232.198.64/28",  # I2N
-  "35.178.165.173/32", # Bastion Dev for FoxyProxy
 ]
 
 # jenkins access


### PR DESCRIPTION
This will instead be implemented by pulling the Bastion IPs from Terraform state, in the hmpps-delius-core-terraform and hmpps-mis-terraform-repo projects.