### PR TITLE
Increase storage size for the contact-search to handle secondary index

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -509,7 +509,7 @@ default_contact_search_config = {
   dedicated_master_enabled      = true
   dedicated_master_count        = 3 # See https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-dedicatedmasternodes.html
   dedicated_master_type         = "m6g.large.elasticsearch"
-  volume_size                   = 128
+  volume_size                   = 256
   volume_type                   = "gp2"
   automated_snapshot_start_hour = 23
 }


### PR DESCRIPTION
A full contact index takes up ~650GB, and the max storage is currently 128*6 = 768GB. This is being increased to ~1.5TB, so that we can run two concurrent indices - for the purposes of re-indexing during live service.