### PR TITLE
Add preprod hmpps auth access so that it can connect to stage

### DIFF
--- a/delius-stage/sub-projects/delius-core.tfvars
+++ b/delius-stage/sub-projects/delius-core.tfvars
@@ -67,6 +67,12 @@ delius_api_secrets = {
   SPRING_DATASOURCE_PASSWORD     = "/delius-stage/delius/delius-database/db/delius_api_pool_password"
 }
 
+# Community API
+community_api_ingress = [
+  "51.140.228.7/32",  # azure hmpps-auth legacy server
+  "20.39.163.219/32", # azure hmpps-auth nomisapi-preprod
+]
+
 env_user_access_cidr_blocks = [
   # -i2n (Northgate) bastion IP traffic
   "62.232.198.68/32",


### PR DESCRIPTION
HMPPS Auth can either connect to preprod or stage when authentication users; both environments are equally valid so this gives flexibility depending on the specific testing required