### PR TITLE
NIT-40 temporarily increase resource allocations

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -158,9 +158,8 @@ alfresco_share_configs = {
 
 # content
 alfresco_content_configs = {
-  cpu       = "8192"
-  memory    = "25000"
-  heap_size = "24000"
+  cpu       = "16384"
+  memory    = "98304"
 }
 
 # alf solr


### PR DESCRIPTION
This is to allow a single alfresco-content instance to handle expected load while we tested a resilient version of the implementation