### PR TITLE
NIT-90 optimise solr backup policy

### DIFF
--- a/delius-prod/sub-projects/alfresco.tfvars
+++ b/delius-prod/sub-projects/alfresco.tfvars
@@ -114,4 +114,9 @@ alf_backups_map = {
   backups_expiration = 300
 }
 
+alfresco_search_solr_configs_overrides = {
+  backup_cold_storage_after = 14
+  backup_delete_after       = 120
+}
+
 solr_cmis_managed = true


### PR DESCRIPTION
This change allows us to control the backup policy with more granularity. There is no reason for longterm backups of non-prod environments