### PR TITLE
NIT-158 point alfresco-dev at a dev registry

### DIFF
--- a/alfresco-dev/sub-projects/alfresco.tfvars
+++ b/alfresco-dev/sub-projects/alfresco.tfvars
@@ -81,3 +81,15 @@ alf_restore_status = "restore"
 alf_elk_service_map = {
   create_service_role = 0
 }
+
+alfresco_content_configs = {
+  image_url = "563502482979.dkr.ecr.eu-west-2.amazonaws.com/hmpps/alfresco-content"
+}
+
+alfresco_ro_content_configs = {
+  image_url = "563502482979.dkr.ecr.eu-west-2.amazonaws.com/hmpps/alfresco-content"
+}
+
+alfresco_share_configs = {
+  image_url = "563502482979.dkr.ecr.eu-west-2.amazonaws.com/hmpps/alfresco-share"
+}


### PR DESCRIPTION
This is to allow Zaizi devs to push and test images in alfresco-dev without our intervention