### PR TITLE
Adding delius-db params related to EBS volume types

### DIFF
--- a/delius-core-dev/sub-projects/delius-core.tfvars
+++ b/delius-core-dev/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "small"
-  instance_type       = "t3.large"
-  disks_quantity      = 2 # Do not decrease this
-  disks_quantity_data = 1
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 500 # Do not decrease this
-  disk_size_flash     = 500 # Do not decrease this
+  database_size        = "small"
+  instance_type        = "t3.large" # maps to instance_type aws_instance attribute
+  disk_type_data       = "gp3"      # Requires iops and throughput to be set
+  disk_throughput_data = 125        # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "gp3"      # Requires iops and throughput to be set
+  disk_throughput_root = 125        # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 2          # Do not decrease this
+  disks_quantity_data  = 1
+  disk_iops_root       = 3000
+  disk_iops_data       = 3000 # Used for setting ebs volume iops if disks_quantity value applicable, if not flash value used
+  disk_iops_flash      = 3000 # Used for setting ebs volume iops if disks_quantity value not applicable
+  disk_size_data       = 500  # Do not decrease this
+  disk_size_flash      = 500  # Do not decrease this
   ## total_storage    = 1000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-core-sandpit-2/sub-projects/delius-core.tfvars
+++ b/delius-core-sandpit-2/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "small"
-  instance_type       = "t3.large"
-  disks_quantity      = 2 # Do not decrease this
-  disks_quantity_data = 1
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 500 # Do not decrease this
-  disk_size_flash     = 500 # Do not decrease this
+  database_size        = "small"
+  instance_type        = "t3.large" # maps to instance_type aws_instance attribute
+  disk_type_data       = "gp3"      # Requires iops and throughput to be set
+  disk_throughput_data = 125        # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "gp3"      # Requires iops and throughput to be set
+  disk_throughput_root = 125        # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 2          # Do not decrease this
+  disks_quantity_data  = 1
+  disk_iops_root       = 3000
+  disk_iops_data       = 3000 # Used for setting ebs volume iops if disks_quantity value applicable, if not flash value used
+  disk_iops_flash      = 3000 # Used for setting ebs volume iops if disks_quantity value not applicable
+  disk_size_data       = 500  # Do not decrease this
+  disk_size_flash      = 500  # Do not decrease this
   ## total_storage    = 1000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-core-sandpit/sub-projects/delius-core.tfvars
+++ b/delius-core-sandpit/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "small"
-  instance_type       = "t3.large"
-  disks_quantity      = 2 # Do not decrease this
-  disks_quantity_data = 1
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 500 # Do not decrease this
-  disk_size_flash     = 500 # Do not decrease this
+  database_size        = "small"
+  instance_type        = "t3.large"
+  disk_type_data       = "gp3" # Requires iops and throughput to be set
+  disk_throughput_data = 125   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "gp3" # Requires iops and throughput to be set
+  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 2     # Do not decrease this
+  disks_quantity_data  = 1
+  disk_iops_root       = 3000
+  disk_iops_data       = 3000
+  disk_iops_flash      = 3000
+  disk_size_data       = 500 # Do not decrease this
+  disk_size_flash      = 500 # Do not decrease this
   ## total_storage    = 1000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-mis-dev/sub-projects/delius-core.tfvars
+++ b/delius-mis-dev/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "small"
-  instance_type       = "t3.large"
-  disks_quantity      = 2 # Do not decrease this
-  disks_quantity_data = 1
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 500 # Do not decrease this
-  disk_size_flash     = 500 # Do not decrease this
+  database_size        = "small"
+  instance_type        = "t3.large" # maps to instance_type aws_instance attribute
+  disk_type_data       = "io1"      # Requires iops and throughput to be set
+  disk_throughput_data = 125        # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1"      # Requires iops and throughput to be set
+  disk_throughput_root = 125        # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 2          # Do not decrease this
+  disks_quantity_data  = 1
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 500 # Do not decrease this
+  disk_size_flash      = 500 # Do not decrease this
   ## total_storage    = 1000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-mis-test/sub-projects/delius-core.tfvars
+++ b/delius-mis-test/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "small"
-  instance_type       = "t3.large"
-  disks_quantity      = 2 # Do not decrease this
-  disks_quantity_data = 1
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 500 # Do not decrease this
-  disk_size_flash     = 500 # Do not decrease this
+  database_size        = "small"
+  instance_type        = "t3.large" # maps to instance_type aws_instance attribute
+  disk_type_data       = "io1"      # Requires iops and throughput to be set
+  disk_throughput_data = 125        # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1"      # Requires iops and throughput to be set
+  disk_throughput_root = 125        # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 2          # Do not decrease this
+  disks_quantity_data  = 1
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 500 # Do not decrease this
+  disk_size_flash      = 500 # Do not decrease this
   ## total_storage    = 1000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-perf/sub-projects/delius-core.tfvars
+++ b/delius-perf/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "x_large"
-  instance_type       = "r5.4xlarge"
-  disks_quantity      = 16 # Do not decrease this
-  disks_quantity_data = 10
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 1000 # Do not decrease this
-  disk_size_flash     = 1000 # Do not decrease this
+  database_size        = "x_large"
+  instance_type        = "r5.4xlarge"
+  disk_type_data       = "io1" # Requires iops and throughput to be set
+  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1" # Requires iops and throughput to be set
+  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 16    # Do not decrease this
+  disks_quantity_data  = 10
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 1000 # Do not decrease this
+  disk_size_flash      = 1000 # Do not decrease this
   ## total_storage    = 16000 # This should equal disks_quantity x disk_size
 }
 
@@ -44,16 +49,16 @@ delius_app_config = {
 
 # GDPR
 gdpr_config = {
-  api_min_capacity = 1 # Batch processing currently doesn't scale so fixing to 1 instance
-  api_max_capacity = 1
+  api_min_capacity            = 1 # Batch processing currently doesn't scale so fixing to 1 instance
+  api_max_capacity            = 1
   cron_identifyduplicates     = "-" # Batch schedules. Set to "-" to disable.
   cron_retainedoffenders      = "-" #
   cron_retainedoffendersiicsa = "-" #
   cron_eligiblefordeletion    = "-" #
   cron_deleteoffenders        = "-" #
   cron_destructionlogclearing = "-" #
-  ui_min_capacity  = 2
-  ui_max_capacity  = 10
+  ui_min_capacity             = 2
+  ui_max_capacity             = 10
 }
 
 # Delius API

--- a/delius-pre-prod/sub-projects/delius-core.tfvars
+++ b/delius-pre-prod/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "x_large"
-  instance_type       = "r5.4xlarge"
-  disks_quantity      = 16 # Do not decrease this
-  disks_quantity_data = 10
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 1000 # Do not decrease this
-  disk_size_flash     = 1000 # Do not decrease this
+  database_size        = "x_large"
+  instance_type        = "r5.4xlarge"
+  disk_type_data       = "io1" # Requires iops and throughput to be set
+  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1" # Requires iops and throughput to be set
+  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 16    # Do not decrease this
+  disks_quantity_data  = 10
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 1000 # Do not decrease this
+  disk_size_flash      = 1000 # Do not decrease this
   ## total_storage    = 16000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-prod/sub-projects/delius-core.tfvars
+++ b/delius-prod/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "x_large"
-  instance_type       = "r5.4xlarge"
-  disks_quantity      = 16 # Do not decrease this
-  disks_quantity_data = 10
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 1000 # Do not decrease this
-  disk_size_flash     = 1000 # Do not decrease this
+  database_size        = "x_large"
+  instance_type        = "r5.4xlarge"
+  disk_type_data       = "io1" # Requires iops and throughput to be set
+  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1" # Requires iops and throughput to be set
+  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 16    # Do not decrease this
+  disks_quantity_data  = 10
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 1000 # Do not decrease this
+  disk_size_flash      = 1000 # Do not decrease this
   ## total_storage    = 16000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-stage/sub-projects/delius-core.tfvars
+++ b/delius-stage/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "x_large"
-  instance_type       = "r5.2xlarge"
-  disks_quantity      = 16 # Do not decrease this
-  disks_quantity_data = 10
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 1000 # Do not decrease this
-  disk_size_flash     = 1000 # Do not decrease this
+  database_size        = "x_large"
+  instance_type        = "r5.2xlarge"
+  disk_type_data       = "io1" # Requires iops and throughput to be set
+  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1" # Requires iops and throughput to be set
+  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 16    # Do not decrease this
+  disks_quantity_data  = 10
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 1000 # Do not decrease this
+  disk_size_flash      = 1000 # Do not decrease this
   ## total_storage    = 16000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-test/sub-projects/delius-core.tfvars
+++ b/delius-test/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "medium"
-  instance_type       = "r5.xlarge"
-  disks_quantity      = 4 # Do not decrease this
-  disks_quantity_data = 2
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 500 # Do not decrease this
-  disk_size_flash     = 500 # Do not decrease this
+  database_size        = "medium"
+  instance_type        = "r5.xlarge"
+  disk_type_data       = "io1" # Requires iops and throughput to be set
+  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1" # Requires iops and throughput to be set
+  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 4     # Do not decrease this
+  disks_quantity_data  = 2
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 500 # Do not decrease this
+  disk_size_flash      = 500 # Do not decrease this
   ## total_storage    = 2000 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-training-test/sub-projects/delius-core.tfvars
+++ b/delius-training-test/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "small"
-  instance_type       = "t3.large"
-  disks_quantity      = 2 # Do not decrease this
-  disks_quantity_data = 1
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 200 # Do not decrease this
-  disk_size_flash     = 200 # Do not decrease this
+  database_size        = "small"
+  instance_type        = "t3.large"
+  disk_type_data       = "io1" # Requires iops and throughput to be set
+  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1" # Requires iops and throughput to be set
+  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 2     # Do not decrease this
+  disks_quantity_data  = 1
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 200 # Do not decrease this
+  disk_size_flash      = 200 # Do not decrease this
   ## total_storage    = 400 # This should equal disks_quantity x disk_size
 }
 

--- a/delius-training/sub-projects/delius-core.tfvars
+++ b/delius-training/sub-projects/delius-core.tfvars
@@ -3,14 +3,19 @@
 
 # ref ../../common/common.tfvars
 db_size_delius_core = {
-  database_size       = "small"
-  instance_type       = "t3.large"
-  disks_quantity      = 2 # Do not decrease this
-  disks_quantity_data = 1
-  disk_iops_data      = 1000
-  disk_iops_flash     = 500
-  disk_size_data      = 500 # Do not decrease this
-  disk_size_flash     = 500 # Do not decrease this
+  database_size        = "small"
+  instance_type        = "t3.large"
+  disk_type_data       = "io1" # Requires iops and throughput to be set
+  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "io1" # Requires iops and throughput to be set
+  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disks_quantity       = 2     # Do not decrease this
+  disks_quantity_data  = 1
+  disk_iops_root       = 1000
+  disk_iops_data       = 1000
+  disk_iops_flash      = 500
+  disk_size_data       = 500 # Do not decrease this
+  disk_size_flash      = 500 # Do not decrease this
   ## total_storage    = 1000 # This should equal disks_quantity x disk_size
 }
 


### PR DESCRIPTION
Work item https://dsdmoj.atlassian.net/browse/NIT-161
Related IaC: https://github.com/ministryofjustice/hmpps-oracle-database/pull/19

To apply this change, a further PR will be required to bump the version reference in the module call to the oracle-database module, e.g. here https://github.com/ministryofjustice/hmpps-delius-core-terraform/blob/main/database_failover/server-delius-db-1.tf#L12

This PR provides the additional data in changes made to the oracle-database terraform module (PR above)
The approach to changing data values was
- Make changes to configure delius-sandpit and delius-core-dev to use gp3 volumes (for both data and root) as opposed to io1
- Ensure that values for new variables for all other environments remain set for io1. (Further changes may adjust these)