### PR TITLE
Added var database_primary set to true for all delius-core environments

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -504,6 +504,10 @@ database_high_availability_count = {
   misdsd = 2
 }
 
+database_primary = {
+  delius = true
+}
+
 # How long we keep our indices for in elastic search in days
 retention_period = 365
 

--- a/common/common.tfvars
+++ b/common/common.tfvars
@@ -415,6 +415,10 @@ database_high_availability_count = {
   misdsd = 0
 }
 
+database_primary = {
+  delius = true
+}
+
 # How long we keep our indices for in elastic search in days
 retention_period = 60
 

--- a/delius-core-dev/delius-core-dev.tfvars
+++ b/delius-core-dev/delius-core-dev.tfvars
@@ -28,6 +28,10 @@ database_high_availability_count = {
   misdsd = 0
 }
 
+database_primary = {
+  delius = true
+}
+
 oracle_delete_unused_dbids = "yes"
 
 oracle_rotate_passwords_schedule = {

--- a/delius-core-sandpit/delius-core-sandpit.tfvars
+++ b/delius-core-sandpit/delius-core-sandpit.tfvars
@@ -36,6 +36,10 @@ database_high_availability_count = {
   misdsd = 0
 }
 
+database_primary = {
+  delius = true
+}
+
 oracle_rotate_passwords_schedule = {
     schedule_expression   =  "00 11 ? * TUE *"
 }

--- a/delius-perf/delius-perf.tfvars
+++ b/delius-perf/delius-perf.tfvars
@@ -30,6 +30,10 @@ database_high_availability_count = {
   misdsd = 0
 }
 
+database_primary = {
+  delius = true
+}
+
 oracle_rotate_passwords_schedule = {
     schedule_expression   =  "00 10 ? * WED *"
 }

--- a/delius-pre-prod/delius-pre-prod.tfvars
+++ b/delius-pre-prod/delius-pre-prod.tfvars
@@ -74,3 +74,7 @@ database_high_availability_count = {
   misboe = 1
   misdsd = 1
 }
+
+database_primary = {
+  delius = true
+}

--- a/delius-stage/delius-stage.tfvars
+++ b/delius-stage/delius-stage.tfvars
@@ -64,6 +64,10 @@ database_high_availability_count = {
   misdsd = 0
 }
 
+database_primary = {
+  delius = true
+}
+
 oracle_rotate_passwords_schedule = {
     schedule_expression   =  "00 16 ? * WED *"
 }

--- a/delius-test/delius-test.tfvars
+++ b/delius-test/delius-test.tfvars
@@ -37,6 +37,10 @@ database_high_availability_count = {
   misdsd = 0
 }
 
+database_primary = {
+  delius = true
+}
+
 oracle_delete_unused_dbids = "yes"
 
 oracle_rotate_passwords_schedule = {

--- a/delius-training/delius-training.tfvars
+++ b/delius-training/delius-training.tfvars
@@ -47,6 +47,10 @@ database_high_availability_count = {
   misdsd = 0
 }
 
+database_primary = {
+  delius = true
+}
+
 oracle_delete_unused_dbids = "yes"
 
 oracle_rotate_passwords_schedule = {


### PR DESCRIPTION
As requested in the ticket https://dsdmoj.atlassian.net/browse/NIT-162
we want to decrease number of delius database instances (remove AZ2 and/or AZ3 db instances depending on the environment).

In case of delius-sandpit we want to remove all database instances (primaryDB + standby DBs) therefore the following change consists of adding the variable _database_primary_ to all delius-core environments.
- database_primary = true -> PrimaryDB step performed in delius-core-terraform pipeline
- database_primary = false -> PrimaryDB step not to be performed in delius-core-terraform pipeline