### PR TITLE
Remove standby DB in delius-test environment

### DIFF
--- a/delius-test/delius-test.tfvars
+++ b/delius-test/delius-test.tfvars
@@ -31,7 +31,7 @@ oracle_validate_backup_schedule = {
 }
 
 database_high_availability_count = {
-  delius = 1
+  delius = 0
   mis    = 0
   misboe = 0
   misdsd = 0


### PR DESCRIPTION
Remove delius standby DB in delius-test environment.
Ticket. https://dsdmoj.atlassian.net/browse/NIT-162