### PR TITLE
Set Apply Lag Threshold for MIS Standby

### DIFF
--- a/delius-pre-prod/ansible/group_vars/mis_standbydb1.yml
+++ b/delius-pre-prod/ansible/group_vars/mis_standbydb1.yml
@@ -18,3 +18,5 @@ required_patches:
       database_patch: true
       datapatch_required: false
       replaces_patch: "30616738"
+data_guard_parameters:
+   ApplyLagThreshold: 600

--- a/delius-prod/ansible/group_vars/mis_standbydb1.yml
+++ b/delius-prod/ansible/group_vars/mis_standbydb1.yml
@@ -18,3 +18,5 @@ required_patches:
       database_patch: true
       datapatch_required: false
       replaces_patch: "30616738"
+data_guard_parameters:
+   ApplyLagThreshold: 600


### PR DESCRIPTION
During overnight processing apply lag for MIS Standby may be up to 10 minutes.
This is monitored using OEM using Adaptive Thresholds which accommodate different overnight thresholds so we do not want a alert for a 30 second lag all day.