### PR TITLE
Add specific alfresco db pool props for alfresco-dev

### DIFF
--- a/alfresco-dev/sub-projects/alfresco.tfvars
+++ b/alfresco-dev/sub-projects/alfresco.tfvars
@@ -83,13 +83,13 @@ alf_elk_service_map = {
 }
 
 alfresco_content_configs = {
-  image_url = "563502482979.dkr.ecr.eu-west-2.amazonaws.com/hmpps/alfresco-content"
+  image_url       = "563502482979.dkr.ecr.eu-west-2.amazonaws.com/hmpps/alfresco-content"
   db_pool_initial = 100
   db_pool_max     = 300
 }
 
 alfresco_ro_content_configs = {
-  image_url = "563502482979.dkr.ecr.eu-west-2.amazonaws.com/hmpps/alfresco-content"
+  image_url       = "563502482979.dkr.ecr.eu-west-2.amazonaws.com/hmpps/alfresco-content"
   db_pool_initial = 100
   db_pool_max     = 300
 }


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-206

A follow up to https://github.com/ministryofjustice/hmpps-env-configs/pull/2037, to fix an issue with the way that alfresco-dev consumes TF variables.