### PR TITLE
Throttle PRDBOE Full Backup

### DIFF
--- a/delius-prod/ansible/group_vars/misboe_primarydb.yml
+++ b/delius-prod/ansible/group_vars/misboe_primarydb.yml
@@ -37,3 +37,4 @@ oracle_software:
       opatch:
           version: 12.2.0.1.25
           filename: p6880880_190000_Linux-x86-64.zip
+rman_level_0_backup_duration_target: "06:00"


### PR DESCRIPTION
Throttle PRDBOE Full Backup to prevent high CPU alert (since static time based monitoring thresholds not working in OEM 13.4)