### PR TITLE
Delius DB EBS vol optimisation - delius-test env

### DIFF
--- a/delius-test/sub-projects/delius-core.tfvars
+++ b/delius-test/sub-projects/delius-core.tfvars
@@ -5,14 +5,14 @@
 db_size_delius_core = {
   database_size        = "medium"
   instance_type        = "r5.xlarge"
-  disk_type_data       = "io1" # Requires iops and throughput to be set
-  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
-  disk_type_root       = "io1" # Requires iops and throughput to be set
+  disk_type_data       = "gp3" # Requires iops and throughput to be set
+  disk_throughput_data = 150   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "gp3" # Requires iops and throughput to be set
   disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
   disks_quantity       = 4     # Do not decrease this
   disks_quantity_data  = 2
-  disk_iops_root       = 1000
-  disk_iops_data       = 1000
+  disk_iops_root       = 3000
+  disk_iops_data       = 3000
   disk_iops_flash      = 500
   disk_size_data       = 500 # Do not decrease this
   disk_size_flash      = 500 # Do not decrease this


### PR DESCRIPTION
Change EBS volume type from io1 to gp3 type for delius-test env.
Ticket no. https://dsdmoj.atlassian.net/browse/NIT-187