### PR TITLE
Delius DB EBS vol optimisation - delius-pre-prod env

### DIFF
--- a/delius-pre-prod/sub-projects/delius-core.tfvars
+++ b/delius-pre-prod/sub-projects/delius-core.tfvars
@@ -5,15 +5,15 @@
 db_size_delius_core = {
   database_size        = "x_large"
   instance_type        = "r5.4xlarge"
-  disk_type_data       = "io1" # Requires iops and throughput to be set
-  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
-  disk_type_root       = "io1" # Requires iops and throughput to be set
-  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disk_type_data       = "gp3" # Requires iops and throughput to be set
+  disk_throughput_data = 700   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "gp3" # Requires iops and throughput to be set
+  disk_throughput_root = 700   # Only relevant when disks_volume_type = "gp3"
   disks_quantity       = 16    # Do not decrease this
   disks_quantity_data  = 10
-  disk_iops_root       = 1000
-  disk_iops_data       = 1000
-  disk_iops_flash      = 500
+  disk_iops_root       = 3000
+  disk_iops_data       = 3000
+  disk_iops_flash      = 3000
   disk_size_data       = 1000 # Do not decrease this
   disk_size_flash      = 1000 # Do not decrease this
   ## total_storage    = 16000 # This should equal disks_quantity x disk_size


### PR DESCRIPTION
Change EBS volume type from io1 to gp3 type for delius-pre-prod env.
Ticket no. https://dsdmoj.atlassian.net/browse/NIT-241