### PR TITLE
Delius DB EBS vol optimisation - delius-training

### DIFF
--- a/delius-training/sub-projects/delius-core.tfvars
+++ b/delius-training/sub-projects/delius-core.tfvars
@@ -5,15 +5,15 @@
 db_size_delius_core = {
   database_size        = "small"
   instance_type        = "t3.large"
-  disk_type_data       = "io1" # Requires iops and throughput to be set
-  disk_throughput_data = 750   # Only relevant when disks_volume_type = "gp3"
-  disk_type_root       = "io1" # Requires iops and throughput to be set
-  disk_throughput_root = 125   # Only relevant when disks_volume_type = "gp3"
+  disk_type_data       = "gp3" # Requires iops and throughput to be set
+  disk_throughput_data = 400   # Only relevant when disks_volume_type = "gp3"
+  disk_type_root       = "gp3" # Requires iops and throughput to be set
+  disk_throughput_root = 400   # Only relevant when disks_volume_type = "gp3"
   disks_quantity       = 2     # Do not decrease this
   disks_quantity_data  = 1
-  disk_iops_root       = 1000
-  disk_iops_data       = 1000
-  disk_iops_flash      = 500
+  disk_iops_root       = 3000
+  disk_iops_data       = 3000
+  disk_iops_flash      = 3000
   disk_size_data       = 500 # Do not decrease this
   disk_size_flash      = 500 # Do not decrease this
   ## total_storage    = 1000 # This should equal disks_quantity x disk_size


### PR DESCRIPTION
Change EBS volume type from io1 to gp3 type for delius-training env.
Ticket no. https://dsdmoj.atlassian.net/browse/NIT-241