### PR TITLE
NIT-243 halve provisioned iops for alfresco DBs

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -121,7 +121,7 @@ alf_ops_alerts = {
 
 alf_rds_props = {
   instance_class          = "db.r5.xlarge"
-  iops                    = 10000
+  iops                    = 5000
   storage_type            = "io1"
   allocated_storage       = 1000
   maintenance_window      = "Wed:19:30-Wed:21:30"

--- a/delius-pre-prod/sub-projects/alfresco.tfvars
+++ b/delius-pre-prod/sub-projects/alfresco.tfvars
@@ -79,7 +79,7 @@ alf_snapshot_identifier = "alfresco-database-snapshot"
 # Environment-specific configuration for alfresco-database RDS instance
 alf_rds_props = {
   instance_class          = "db.m5.2xlarge"
-  iops                    = 10000
+  iops                    = 5000
   storage_type            = "io1"
   allocated_storage       = 1000
   maintenance_window      = "Wed:19:30-Wed:21:30"

--- a/delius-prod/sub-projects/alfresco.tfvars
+++ b/delius-prod/sub-projects/alfresco.tfvars
@@ -86,7 +86,7 @@ alf_ops_alerts = {
 # Environment-specific configuration for alfresco-database RDS instance
 alf_rds_props = {
   instance_class          = "db.m5.12xlarge"
-  iops                    = 10000
+  iops                    = 5000
   storage_type            = "io1"
   allocated_storage       = 1000
   maintenance_window      = "Wed:19:30-Wed:21:30"

--- a/delius-stage/sub-projects/alfresco.tfvars
+++ b/delius-stage/sub-projects/alfresco.tfvars
@@ -96,7 +96,7 @@ alf_snapshot_identifier = "alfresco-database-snapshot"
 # Environment-specific configuration for alfresco-database RDS instance
 alf_rds_props = {
   instance_class          = "db.m5.2xlarge"
-  iops                    = 10000
+  iops                    = 5000
   storage_type            = "io1"
   allocated_storage       = 1000
   maintenance_window      = "Wed:19:30-Wed:21:30"


### PR DESCRIPTION
currently over-provisioned. halving will still live a lot of headroom based on observed metrics