### PR TITLE
Add Unilink Read Only Users to Prod

### DIFF
--- a/delius-prod/ansible/group_vars/delius_primarydb.yml
+++ b/delius-prod/ansible/group_vars/delius_primarydb.yml
@@ -21,6 +21,17 @@ delius_users:
   smauthoor_sro:
   acody_sro:
   worr_sro:
+  jmacbeth_ro:
+  jdundon_ro:
+  mthapa_ro:
+  maspin_ro:
+  mweatherall_ro:
+  mlaskowski_ro:
+  pmiller_ro:
+  pwilson_ro:
+  rmccormack_ro:
+  svalmonte_ro:
+  yfedkiv_dba:
 oracle_software:
   version: 19.16
   superset_patch: p34130714_190000_Linux-x86-64.zip


### PR DESCRIPTION
Read Only users are not normally created on Production.   This is a special request from Michael and approved by Nic to allow this access for Unilink users who already have R/W access via the DELIUS_APP_SCHEMA account.   This account should be used by default to limit unintentional production changes.   _RO accounts are used instead of _SRO accounts in case of a need to investigate issues during a release or other time when Standby may not be in sync.