### PR TITLE
Move Level 0 Backups to Wednesdays to Reduce Bank Holiday Impacts

### DIFF
--- a/delius-core-dev/delius-core-dev.tfvars
+++ b/delius-core-dev/delius-core-dev.tfvars
@@ -17,8 +17,8 @@ create_autostop_instance     = "true"
 # oracle_backup_schedule should be specified using the Europe/London timezone (i.e DST is handled automatically)
 oracle_backup_schedule = {
   delius = {
-    daily_schedule  = "30 06 ? * 3-6 *"
-    weekly_schedule = "30 06 ? * 2 *"
+    daily_schedule  = "30 06 ? * 2,3,5,6 *"
+    weekly_schedule = "30 06 ? * 4 *"
   }
 }
 

--- a/delius-mis-dev/delius-mis-dev.tfvars
+++ b/delius-mis-dev/delius-mis-dev.tfvars
@@ -17,20 +17,20 @@ mis_overide_resizing_schedule_tags   = "false"     ##Set resizing schedule tag k
 # oracle_backup_schedule should be specified using the Europe/London timezone (i.e DST is handled automatically)
 oracle_backup_schedule = {
   delius = {
-    daily_schedule  = "30 06 ? * 3-6 *"
-    weekly_schedule = "30 06 ? * 2 *"
+    daily_schedule  = "30 06 ? * 2,3,5,6 *"
+    weekly_schedule = "30 06 ? * 4 *"
   },
   mis = {
-    daily_schedule  = "30 06 ? * 3-6 *"
-    weekly_schedule = "30 06 ? * 2 *"
+    daily_schedule  = "30 06 ? * 2,3,5,6 *"
+    weekly_schedule = "30 06 ? * 4 *"
   },
   misboe = {
-    daily_schedule  = "30 06 ? * 3-6 *"
-    weekly_schedule = "30 06 ? * 2 *"
+    daily_schedule  = "30 06 ? * 2,3,5,6 *"
+    weekly_schedule = "30 06 ? * 4 *"
   },
   misdsd = {
-    daily_schedule  = "30 06 ? * 3-6 *"
-    weekly_schedule = "30 06 ? * 2 *"
+    daily_schedule  = "30 06 ? * 2,3,5,6 *"
+    weekly_schedule = "30 06 ? * 4 *"
   }
 }
 

--- a/delius-test/delius-test.tfvars
+++ b/delius-test/delius-test.tfvars
@@ -19,8 +19,8 @@ create_autostop_instance     = "true"
 # oracle_backup_schedule should be specified using the Europe/London timezone (i.e DST is handled automatically)
 oracle_backup_schedule = {
   delius = {
-    daily_schedule  = "30 20 ? * 3-6 *"
-    weekly_schedule = "30 20 ? * 2 *"
+    daily_schedule  = "30 20 ? * 2,3,5,6 *"
+    weekly_schedule = "30 20 ? * 4 *"
   }
 }
 

--- a/delius-training/delius-training.tfvars
+++ b/delius-training/delius-training.tfvars
@@ -22,7 +22,7 @@ create_autostop_instance     = "true"
 # oracle_backup_schedule should be specified using the Europe/London timezone (i.e DST is handled automatically)
 oracle_backup_schedule = {
   delius = {
-    daily_schedule  = "30 06 ? * 2,3,5,6 *"
+    daily_schedule  = "30 06 ? * 3,5,6 *"
     weekly_schedule = "30 06 ? * 4 *"
   }
 }

--- a/delius-training/delius-training.tfvars
+++ b/delius-training/delius-training.tfvars
@@ -22,15 +22,15 @@ create_autostop_instance     = "true"
 # oracle_backup_schedule should be specified using the Europe/London timezone (i.e DST is handled automatically)
 oracle_backup_schedule = {
   delius = {
-    daily_schedule  = "30 06 ? * 4-6 *"
-    weekly_schedule = "30 06 ? * 3 *"
+    daily_schedule  = "30 06 ? * 2,3,5,6 *"
+    weekly_schedule = "30 06 ? * 4 *"
   }
 }
 
 oracle_validate_backup_schedule = {
   delius = {
     host     =  "delius_primarydb"
-    schedule =  "00 18 ? * 4 *"
+    schedule =  "00 18 ? * 5 *"
   }
 }
 


### PR DESCRIPTION
Level 0 backups of lower environments should run on Wednesdays instead of Mondays to reduce impact of bank holiday shutdowns in those environments.
Note that there is still the possibility for level 0 backups to be skipped during Christmas or New Year holidays in some years, but the overall number of skipped runs will be smaller.