### PR TITLE
Disable lambda function which resizes ETL ec2 instance

### DIFF
--- a/delius-prod/delius-prod.tfvars
+++ b/delius-prod/delius-prod.tfvars
@@ -12,7 +12,7 @@ route53_domain_private = "service.justice.gov.uk"
 
 subdomain = "probation"
 
-mis_overide_resizing_schedule_tags   = "true"     ##Set resizing schedule tag key value for MIS Servers
+mis_overide_resizing_schedule_tags   = "false"     ##Set resizing schedule tag key value for MIS Servers
 
 
 #Instance size for smtp server


### PR DESCRIPTION
Stop lambda function in prod while investigating options to fix the issue.
Ticket no. https://dsdmoj.atlassian.net/browse/NIT-716

