### PR TITLE
Set DSS heap size to 2.5GB + increase container memory limit to 3.5GB.

### DIFF
--- a/common-prod/common.tfvars
+++ b/common-prod/common.tfvars
@@ -776,7 +776,7 @@ dss_job_image = "895523100917.dkr.ecr.eu-west-2.amazonaws.com/hmpps/dss:3.1.6"
 
 dss_job_vcpus = 1
 
-dss_job_memory = 3096
+dss_job_memory = 3584
 
 dss_job_schedule = "cron(00 8 * * ? *)"
 

--- a/delius-prod/sub-projects/delius-core.tfvars
+++ b/delius-prod/sub-projects/delius-core.tfvars
@@ -148,7 +148,7 @@ dss_job_envvars = [
   },
   {
     "name"  = "JAVA_OPTS"
-    "value" = "-Xms1024m -Xmx3072m"
+    "value" = "-Xms1024m -Xmx2560m"
   },
   {
     "name"  = "PARSEERRORMAXLIMITOVERRIDE"


### PR DESCRIPTION
Note: EC2 host limit is 4GB (type=c5.large).