### PR TITLE
Update delius-mis-dev.tfvars

### DIFF
--- a/delius-mis-dev/delius-mis-dev.tfvars
+++ b/delius-mis-dev/delius-mis-dev.tfvars
@@ -11,6 +11,7 @@ autostop_notify_rule_enabled       = "true"
 tagged_user                        = "<@UA84K4FG8>  <@UA8N2QDHR>  <@U9C74KBLP>  <@UAWCS3F0A>"
 channel                            = "auto-stop-alerts"
 create_autostop_instance           = "true"
+delius_overide_autostop_tags       = "False" ##Override Phase1 autostop tag key value for Oracle Primary Servers
 mis_overide_autostop_tags          = "True"  ##Set autostop tag key value for MIS Servers
 mis_overide_resizing_schedule_tags = "false" ##Set resizing schedule tag key value for MIS Servers
 


### PR DESCRIPTION
Override tag with value of "False" so instances in mis-non-prod AWS account are left shutdown after being manually stopped. They have been migrated to MP so no longer need to be running.