### PR TITLE
RBAC => 6.3.8

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -8,7 +8,7 @@ dependencies_bucket:
 
 # Delius LDAP
 ldap_config:
-  rbac_version: 6.2.6 # This default should match the version in Prod
+  rbac_version: 6.3.8 # This default should match the version in Prod
   # The following vars are duplicated in common.tfvars, as they are required by terraform as well as in ansible runtime tasks (eg. RBAC uplift):
   protocol: ldap
   bind_user: cn=admin,dc=moj,dc=com


### PR DESCRIPTION
RBAC is uplifted by integrations pipeline. this is to keep the version dash board right.