### PR TITLE
fix issue where mariadb support in t2 is deprecated

### DIFF
--- a/delius-mis-dev/sub-projects/mis.tfvars
+++ b/delius-mis-dev/sub-projects/mis.tfvars
@@ -201,8 +201,8 @@ ansible_vars_misdsd_db = {
 legacy_environment_name = "100"
 
 #Nextcloud
-nextcloud_instance_type     = "t2.small"
-rds_instance_class          = "db.t2.small"
+nextcloud_instance_type     = "t3.small"
+rds_instance_class          = "db.t3.small"
 mariadb_monitoring_interval = 30
 rds_allocated_storage       = "500"
 number_cache_clusters       = 2


### PR DESCRIPTION
Attempting to test changes in the delius-prod account whereby we're adding permissions to the S3 bucket so that a data-sync job can read the contents. However... would be good to deploy into mis-dev first which has this issue

```
module.db_instance.aws_db_instance.inst: Modifying... [id=tf-eu-west-2-hmpps-delius-mis-dev-nextcloud]

Error: Error modifying DB Instance tf-eu-west-2-hmpps-delius-mis-dev-nextcloud: InvalidParameterCombination: 
RDS does not support creating a DB instance with the following combination: 
DBInstanceClass=db.t2.small, Engine=mariadb, EngineVersion=10.5.27, LicenseModel=general-public-license. 
For supported combinations of instance class and database engine version, see the documentation.
    status code: 400, request id: 910d41e7-82c6-494a-9a61-e5f59e182371

  on ../modules/db_instance/main.tf line 1, in resource "aws_db_instance" "inst":
   1: resource "aws_db_instance" "inst" {
```

db.t2.small instances are deprecated for MariaDB as per [this link](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Support.html) so change to t3  

If you run this query in the AWS cli t2 no longer appears in the list of supported instances

`aws rds describe-orderable-db-instance-options --engine mariadb --engine-version 10.5.27     --query "*[].{DBInstanceClass:DBInstanceClass,StorageType:StorageType}|[?StorageType=='gp2']|[].{DBInstanceClass:DBInstanceClass}" --output text --region eu-west-2` 

NOTE: there is a reference to t2.small in the delius-test sub-project but that seems to be dormant/dead so have not changed that