### PR TITLE
Apply cap of 4 channels for RMAN backups to Prod

### DIFF
--- a/delius-prod/ansible/group_vars/mis_primarydb.yml
+++ b/delius-prod/ansible/group_vars/mis_primarydb.yml
@@ -12,6 +12,7 @@ database_parameters:
    pga_aggregate_limit: 70G
 rman_retention_policy: RECOVERY WINDOW OF 366 DAYS
 rman_level_0_backup_duration_target: "15:00"
+rman_channel_cap: 4
 rman_uncompressed_backup: Y
 required_patches:
     p32044533:


### PR DESCRIPTION
Prevent channels closing due to inactivity.