### PR TITLE
TM-1912: delius-mis: add route53 forwarder to hmpp domain

### DIFF
--- a/delius-mis-dev/sub-projects/mis.tfvars
+++ b/delius-mis-dev/sub-projects/mis.tfvars
@@ -9,7 +9,9 @@ cloudwatch_log_retention = 14
 route53_hosted_zone_id = "Z3VDCLGXC4HLOW"
 
 # CIDR where HMPP domain and FSX are hosted
-modernisation_platform_hmpp_dc_cidr = "10.20.96.0/19"
+modernisation_platform_hmpp_dc_cidr     = "10.20.96.0/19"
+modernisation_platform_hmpp_dc_ips      = ["10.20.104.5", "10.20.106.5"]
+modernisation_platform_hmpp_domain_name = "azure.noms.root"
 
 public_ssl_arn = ""
 

--- a/delius-pre-prod/sub-projects/mis.tfvars
+++ b/delius-pre-prod/sub-projects/mis.tfvars
@@ -9,7 +9,9 @@ cloudwatch_log_retention = 14
 route53_hosted_zone_id = "Z3VDCLGXC4HLOW"
 
 # CIDR where HMPP domain and FSX are hosted
-modernisation_platform_hmpp_dc_cidr = "10.27.136.0/21"
+modernisation_platform_hmpp_dc_cidr     = "10.27.136.0/21"
+modernisation_platform_hmpp_dc_ips      = ["10.27.136.5", "10.27.137.5"]
+modernisation_platform_hmpp_domain_name = "azure.hmpp.root"
 
 public_ssl_arn = ""
 

--- a/delius-prod/sub-projects/mis.tfvars
+++ b/delius-prod/sub-projects/mis.tfvars
@@ -9,7 +9,9 @@ cloudwatch_log_retention = 14
 route53_hosted_zone_id = "Z3VDCLGXC4HLOW"
 
 # CIDR where HMPP domain and FSX are hosted
-modernisation_platform_hmpp_dc_cidr = "10.27.136.0/21"
+modernisation_platform_hmpp_dc_cidr     = "10.27.136.0/21"
+modernisation_platform_hmpp_dc_ips      = ["10.27.136.5", "10.27.137.5"]
+modernisation_platform_hmpp_domain_name = "azure.hmpp.root"
 
 public_ssl_arn = ""
 

--- a/delius-stage/sub-projects/mis.tfvars
+++ b/delius-stage/sub-projects/mis.tfvars
@@ -9,7 +9,9 @@ cloudwatch_log_retention = 14
 route53_hosted_zone_id = "Z2SOZ79CNGAPIF"
 
 # CIDR where HMPP domain and FSX are hosted
-modernisation_platform_hmpp_dc_cidr = "10.27.136.0/21"
+modernisation_platform_hmpp_dc_cidr     = "10.27.136.0/21"
+modernisation_platform_hmpp_dc_ips      = ["10.27.136.5", "10.27.137.5"]
+modernisation_platform_hmpp_domain_name = "azure.hmpp.root"
 
 public_ssl_arn = ""
 


### PR DESCRIPTION
Config for delius-mis route53 forwarder to azure.hmpp.root domain. This will allow NART fileshare to be mounted for ndmis migration.